### PR TITLE
Create some dummy output for the rust-workflows binary command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
 fn main() {
-    env_logger::init();
-    log::info!("hello, world!");
+    let url = "https://github.com/hendrikmaus/rust-workflows";
+
+    println!("Welcome to {}", &url);
+    println!("a reference for Rust workflows to copy, paste and hack on.");
+    println!();
+    println!("This tool does nothing; it is simply a placeholder.");
+    println!("Go to {}", &url);
 }


### PR DESCRIPTION
The `rust-workflows` command is just a placeholder, but actually prints something if run by a user.