### PR TITLE
Crates.io preflight check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -278,7 +278,7 @@ jobs:
   # Publish the release to crates.io if the preflight check let's us continue
   cratesio:
     name: crates.io | publish
-    if: startsWith(github.ref, 'refs/tags/') && needs.cratesio_preflight.outputs.continue == 'true'
+    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.cratesio_preflight.outputs.continue == 'true' }}
     needs:
      - binaries
      - cratesio_preflight

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,8 @@ on:
     tags:
       - 'v*'
     # for testing on a branch
-    #branches:
-    #  - container-image
+    branches:
+      - cratesio-check
 
 env:
   # replace with your binary name as it appears in target/*/release
@@ -243,7 +243,7 @@ jobs:
   # Determine if the crates.io index already has the current release
   cratesio_preflight:
     name: crates.io | preflight
-    if: startsWith(github.ref, 'refs/tags/')
+    #if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     outputs:
       continue: ${{ steps.release.outputs.continue }}
@@ -273,7 +273,8 @@ jobs:
   # Publish the release to crates.io if the preflight check let's us continue
   cratesio:
     name: crates.io | publish
-    if: startsWith(github.ref, 'refs/tags/') && needs.cratesio_preflight.outputs.continue == 'true'
+    #if: startsWith(github.ref, 'refs/tags/') && needs.cratesio_preflight.outputs.continue == 'true'
+    if: needs.cratesio_preflight.outputs.continue == 'true'
     needs:
      - binaries
      - cratesio_preflight
@@ -304,7 +305,8 @@ jobs:
 
       - name: Publish to crates.io
         run: |
-          cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          #cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          echo "cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       - name: Save cache
         uses: hendrikmaus/custom-cache-action/save@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,10 +240,43 @@ jobs:
           docker push "${tag}"
           echo "::endgroup::"
 
-  cratesio:
-    name: Publish to crates.io
+  # Determine if the crates.io index already has the current release
+  cratesio_preflight:
+    name: crates.io | preflight
     if: startsWith(github.ref, 'refs/tags/')
-    needs: binaries
+    runs-on: ubuntu-20.04
+    outputs:
+      continue: ${{ steps.release.outputs.continue }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+
+      - name: Check index
+        id: release
+        run: |
+          index_version=$(cargo search rust-workflows | awk '{print $3}' | tr -d '"')
+          local_version=$(sed -n 's/^version = \"\(.*\)\"/\1/p' Cargo.toml)
+          
+          if [[ "${index_version}" == "${local_version}" ]]; then
+            echo "::set-output name=continue::false"
+            exit 0
+          fi
+          
+          echo "::set-output name=continue::true"
+
+  # Publish the release to crates.io if the preflight check let's us continue
+  cratesio:
+    name: crates.io | publish
+    if: startsWith(github.ref, 'refs/tags/') && needs.cratesio_preflight.outputs.continue == 'true'
+    needs:
+     - binaries
+     - cratesio_preflight
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -261,13 +261,18 @@ jobs:
         id: release
         run: |
           index_version=$(cargo search rust-workflows | awk '{print $3}' | tr -d '"')
+          echo "[INFO] crates.io ${index_version}"
+          
           local_version=$(sed -n 's/^version = \"\(.*\)\"/\1/p' Cargo.toml)
+          echo "[INFO] to-release ${local_version}"
           
           if [[ "${index_version}" == "${local_version}" ]]; then
+            echo "[INFO] skip crates.io publishing"
             echo "::set-output name=continue::false"
             exit 0
           fi
           
+          echo "[INFO] publish to crates.io"
           echo "::set-output name=continue::true"
 
   # Publish the release to crates.io if the preflight check let's us continue

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,8 @@ on:
     tags:
       - 'v*'
     # for testing on a branch
-    branches:
-      - cratesio-check
+    #branches:
+    #  - container-image
 
 env:
   # replace with your binary name as it appears in target/*/release
@@ -243,7 +243,7 @@ jobs:
   # Determine if the crates.io index already has the current release
   cratesio_preflight:
     name: crates.io | preflight
-    #if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     outputs:
       continue: ${{ steps.release.outputs.continue }}
@@ -278,8 +278,7 @@ jobs:
   # Publish the release to crates.io if the preflight check let's us continue
   cratesio:
     name: crates.io | publish
-    #if: startsWith(github.ref, 'refs/tags/') && needs.cratesio_preflight.outputs.continue == 'true'
-    if: needs.cratesio_preflight.outputs.continue == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && needs.cratesio_preflight.outputs.continue == 'true'
     needs:
      - binaries
      - cratesio_preflight
@@ -310,8 +309,7 @@ jobs:
 
       - name: Publish to crates.io
         run: |
-          #cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
-          echo "cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       - name: Save cache
         uses: hendrikmaus/custom-cache-action/save@master


### PR DESCRIPTION
Determine if the crates.io index already knows about this release. One step closer to an idempotent release workflow.