### PR TITLE
Allow re-use of the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,11 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+  # The following makes this workflow re-usable by other repositories
+  # without having to copy the entire thing.
+  # 
+  # See https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+  workflow_call: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -7,6 +7,40 @@ A reference for GitHub Action workflows to use on Rust projects:
 
 Copy, paste and hack away.
 
+## Usage
+
+You either base your own workflows on these by copy & paste _or_ you can call them from your workflow directly.
+
+Here is how you can **re-use** the existing **continuous integration** workflow right away:
+
+```yaml
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+jobs:
+  rust-workflows-ci:
+    name: CI
+    uses: hendrikmaus/rust-workflows/.github/workflows/ci.yaml@v0.8.0
+
+```
+
 ## License
 
 This project is released under the terms of the [MIT](https://opensource.org/licenses/MIT) license.


### PR DESCRIPTION
This change-set adds the `workflow_call` trigger to the CI workflow. It can now be re-used from other repositories without copying the entire thing.