### PR TITLE
Dependabot pr's to be auto-merged using squash

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -35,7 +35,7 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --merge "${PULL_REQUEST}"
+        run: gh pr merge --auto --squash "${PULL_REQUEST}"
         env:
           PULL_REQUEST: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The dependabot pipeline was failing to auto-merge because the repositories merge strategy has been limited to squash.