### PR TITLE
build: add rust toolchain configuration

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.58.1"
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Auto configure the toolchain so everyone uses the same.