### PR TITLE
ci: drop cargo check in favor of clippy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,21 +36,6 @@ defaults:
     shell: bash
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-      - uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
-      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: check
-
   fmt:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
Feedback from https://github.com/hannobraun/Fornjot/pull/208